### PR TITLE
add nexa linux

### DIFF
--- a/aur.sh
+++ b/aur.sh
@@ -34,7 +34,9 @@ source /etc/os-release
         garuda) # Garuda
             echo ">> get-eggs: OK, is Garuda"
             ;;
-        
+        nexalinux) # Nexa Linux
+            echo ">> get-eggs: OK, is Nexa Linux"
+            ;;
         rebornos) # RebornOS
             echo ">> get-eggs: OK, is RebornOS"
             ;;


### PR DESCRIPTION
Nexa Linux is an Arch Linux based distribution, but Penguins' eggs doesn't support it out of the box. It has to be added to aur.sh for it to work. As Nexa Linux depends on Penguins' eggs for ISO production, we need to add this to the script. Please merge if you want, not merging will also be alright.

- komaru