### PR TITLE
Move Nexa Linux to Debian based distributions

### DIFF
--- a/aur.sh
+++ b/aur.sh
@@ -34,9 +34,6 @@ source /etc/os-release
         garuda) # Garuda
             echo ">> get-eggs: OK, is Garuda"
             ;;
-        nexalinux) # Nexa Linux
-            echo ">> get-eggs: OK, is Nexa Linux"
-            ;;
         rebornos) # RebornOS
             echo ">> get-eggs: OK, is RebornOS"
             ;;

--- a/debs.sh
+++ b/debs.sh
@@ -68,6 +68,11 @@ function is_debian {
             echo ">> get-eggs OK, is Kali or derivatives"
             ;;
 
+        # nexa linux
+        nexalinux)
+            echo ">> get-eggs OK, is Nexa Linux or derivatives"
+            ;;
+
         # netrunner derivata da Debian stable
         desktop)
             echo ">> get-eggs OK, is Kali or derivatives"


### PR DESCRIPTION
Nexa Linux is being rebased on Ubuntu, so it has to be moved over to debs.sh.